### PR TITLE
Add osu! API authentication token revoke and client token endpoints

### DIFF
--- a/mi-api/src/api/auth.rs
+++ b/mi-api/src/api/auth.rs
@@ -45,14 +45,13 @@ pub async fn authorize_from_osu_api(
     info!("Successfully got the Osu! user");
 
     let session_token = state.generate_session_token();
+    let refresh_token = auth_response.refresh_token.unwrap();
 
     tokio::try_join!(
         state.redis().set_session_token(user.id, session_token),
-        state.redis().set_osu_tokens(
-            user.id,
-            &auth_response.access_token,
-            &auth_response.refresh_token,
-        )
+        state
+            .redis()
+            .set_osu_tokens(user.id, &auth_response.access_token, &refresh_token)
     )?;
 
     cookies.add(Cookie::new(COOKIE_NAME, session_token.to_string()));

--- a/mi-osu-api/src/auth.rs
+++ b/mi-osu-api/src/auth.rs
@@ -73,9 +73,9 @@ impl AuthRequest {
     // Client Credentials Grant
     fn client() -> AuthRequest {
         AuthRequest {
-            client_id: &MI_CLIENT_ID,
-            client_secret: &MI_CLIENT_SECRET,
-            redirect_uri: &MI_REDIRECT_URI,
+            client_id: &OSU_CLIENT_ID,
+            client_secret: &OSU_CLIENT_SECRET,
+            redirect_uri: &OSU_REDIRECT_URI,
             grant_type: "client_credentials",
             scope: "public",
             code: None,


### PR DESCRIPTION
The added `client_token` method can be used to bypass the [authorization code grant](https://osu.ppy.sh/docs/index.html#authorization-code-grant) to get an authentication token that works on public endpoints. 

I thought that this might be useful in the future so I added it in the API library. The only change, which might affect you is that I had to wrap `refresh_token` field, which in `AuthResponseBody` struct, in an `Option` enum to accommodate this new method because authorization code grant endpoint doesn't return a refresh token.

Another addition is that I also implemented the revoke method to revoke the authorization tokens. This might be needed in case  we want to implement log out functionality.


