### PR TITLE
Fixing bug in db function `init_user`

### DIFF
--- a/mi-db/src/user.rs
+++ b/mi-db/src/user.rs
@@ -1,11 +1,9 @@
 use chrono::Utc;
-use futures::FutureExt;
 use mi_osu_api::Beatmapset;
 use serde::{Deserialize, Serialize};
 use sqlx::types::Json;
 use sqlx::{FromRow, PgPool};
 use thiserror::Error;
-use tokio::try_join;
 use utoipa::ToSchema;
 
 use crate::PG_UNIQUE_KEY_VIOLATION;
@@ -229,50 +227,55 @@ pub async fn upsert_user_mapsets(
 }
 
 pub async fn init_user(user: User, db: &PgPool) -> Result<User, UserError> {
-    let insert_user = sqlx::query_as!(
+    let mut transaction = db.begin().await?;
+
+    // Only the first query is required to be error handled explicityl because of unique key
+    // violation. Other queries return transaction error if the first execution fails.
+    // Therefore, error handle for the first query is done right after the execution.
+
+    let insert_user_result = sqlx::query_as!(
         User,
         "INSERT INTO users (id, user_name, profile_picture) VALUES ($1, $2, $3) RETURNING *",
         user.id,
         user.user_name,
         user.profile_picture,
     )
-    .fetch_one(db);
+    .fetch_one(&mut transaction)
+    .await;
 
-    let insert_profile = sqlx::query!(
-        r#"
-        INSERT INTO user_profiles (user_id) VALUES ($1)"#,
-        user.id,
-    )
-    .execute(db);
-
-    let insert_osu_data = sqlx::query!(
-        r#"INSERT INTO users_osu_data (user_id) VALUES ($1)"#,
-        user.id
-    )
-    .execute(db);
-
-    let insert_result = insert_user
-        .then(|user_res| async move {
-            try_join!(insert_profile, insert_osu_data)?;
-            user_res
-        })
-        .await;
-
-    match insert_result {
-        Ok(inserted_user) => Ok(inserted_user),
+    let inserted_user = match insert_user_result {
+        Ok(inserted_user) => inserted_user,
         Err(db_err) if db_err.as_database_error().is_some() => {
             // We check if db_err can be casted to database_error.
             // PgError should always return a valid error code.
             let pg_db_error_code = db_err.as_database_error().unwrap().code().unwrap();
 
             if pg_db_error_code.eq(PG_UNIQUE_KEY_VIOLATION) {
-                Err(UserError::UserAlreadyExists(user.id))
+                return Err(UserError::UserAlreadyExists(user.id));
             } else {
-                Err(UserError::from(db_err))
+                return Err(UserError::from(db_err));
             }
         }
-        Err(db_err) => Err(UserError::from(db_err)),
-    }
+        Err(db_err) => return Err(UserError::from(db_err)),
+    };
+
+    sqlx::query!(
+        r#"
+        INSERT INTO user_profiles (user_id) VALUES ($1)"#,
+        user.id,
+    )
+    .execute(&mut transaction)
+    .await?;
+
+    sqlx::query!(
+        r#"INSERT INTO users_osu_data (user_id) VALUES ($1)"#,
+        user.id
+    )
+    .execute(&mut transaction)
+    .await?;
+
+    transaction.commit().await?;
+    Ok(inserted_user)
 }
 
 pub async fn update_user_name(user_name: &str, user_id: i64, db: &PgPool) -> Result<(), UserError> {

--- a/mi-db/src/user.rs
+++ b/mi-db/src/user.rs
@@ -229,14 +229,14 @@ pub async fn upsert_user_mapsets(
 }
 
 pub async fn init_user(user: User, db: &PgPool) -> Result<User, UserError> {
-    let insert_user = sqlx::query!(
-        r#"
-        INSERT INTO users (id, user_name, profile_picture) VALUES ($1, $2, $3)"#,
+    let insert_user = sqlx::query_as!(
+        User,
+        "INSERT INTO users (id, user_name, profile_picture) VALUES ($1, $2, $3) RETURNING *",
         user.id,
         user.user_name,
         user.profile_picture,
     )
-    .execute(db);
+    .fetch_one(db);
 
     let insert_profile = sqlx::query!(
         r#"
@@ -244,17 +244,22 @@ pub async fn init_user(user: User, db: &PgPool) -> Result<User, UserError> {
         user.id,
     )
     .execute(db);
+
     let insert_osu_data = sqlx::query!(
         r#"INSERT INTO users_osu_data (user_id) VALUES ($1)"#,
         user.id
     )
     .execute(db);
 
-    let insert_result =
-        insert_user.then(|_user_res| async move { try_join!(insert_profile, insert_osu_data) });
+    let insert_result = insert_user
+        .then(|user_res| async move {
+            try_join!(insert_profile, insert_osu_data)?;
+            user_res
+        })
+        .await;
 
-    match insert_result.await {
-        Ok(_) => Ok(user),
+    match insert_result {
+        Ok(inserted_user) => Ok(inserted_user),
         Err(db_err) if db_err.as_database_error().is_some() => {
             // We check if db_err can be casted to database_error.
             // PgError should always return a valid error code.
@@ -368,29 +373,26 @@ mod tests {
         }
     }
 
-    // TODO: FIX TEST
-    //
-    // #[sqlx::test]
-    // async fn test_insert_user(db: PgPool) {
-    //     // Test user insert
-    //     let user = user_for_test(1);
-    //     init_user(user.clone(), &db).await.unwrap();
-    //     let db_user = get_user(user.id, &db).await.unwrap();
-    //     assert_eq!(user, db_user);
-    //
-    //     // Test user insert with duplicate keys
-    //     let user_second = User {
-    //         // Using the key of the previously inserted user for key violation test
-    //         id: user.id,
-    //         user_name: "fursum".to_string(),
-    //         profile_picture: "random.imageservice.com/fursum.jpg".to_string(),
-    //     };
-    //     let error = init_user(user_second, &db).await.unwrap_err();
-    //     match error {
-    //         UserError::UserAlreadyExists(1) => {}
-    //         _ => panic!("Database should return key violation error on duplicate entries."),
-    //     }
-    // }
+    #[sqlx::test]
+    async fn test_insert_user(db: PgPool) {
+        // Test user insert
+        let user = user_for_test(1i64);
+        init_user(user.clone(), &db).await.unwrap();
+        let db_user = get_user(user.id, &db).await.unwrap();
+        assert_eq!(user, db_user);
+        // Test user insert with duplicate keys
+        let user_second = User {
+            // Using the key of the previously inserted user for key violation test
+            id: 1i64,
+            user_name: "fursum".to_string(),
+            profile_picture: "random.imageservice.com/fursum.jpg".to_string(),
+        };
+        let error = init_user(user_second, &db).await.unwrap_err();
+        match error {
+            UserError::UserAlreadyExists(1) => {}
+            _ => panic!("Database should return key violation error on duplicate entries."),
+        }
+    }
 
     #[sqlx::test]
     async fn test_update_user(db: PgPool) {

--- a/mi-db/src/user.rs
+++ b/mi-db/src/user.rs
@@ -229,7 +229,7 @@ pub async fn upsert_user_mapsets(
 pub async fn init_user(user: User, db: &PgPool) -> Result<User, UserError> {
     let mut transaction = db.begin().await?;
 
-    // Only the first query is required to be error handled explicityl because of unique key
+    // Only the first query is required to be error handled explicitly because of unique key
     // violation. Other queries return transaction error if the first execution fails.
     // Therefore, error handle for the first query is done right after the execution.
 


### PR DESCRIPTION
Old function was directly returning the user struct input argument. This also caused fails in unit tests. This PR addresses this issue #87. Now the function returns the struct that is coming back from the query.

We should also consider converting these chain queries into transactions to avoid data mismatch between tables when one of the queries fail.