### PR TITLE
Moving individual crate dependencies to workspace level `Cargo.toml` as workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,15 +2094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,7 +2394,6 @@ dependencies = [
  "num_cpus",
  "parking_lot 0.12.1",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.45.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,48 @@
 [workspace]
 members = ["mi-api", "mi-db", "mi-osu-api"]
+
+[workspace.package]
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+
+[workspace.dependencies]
+async-trait = "0.1.68"
+axum = { version = "0.6.16", features = ["macros", "http2"] }
+axum-auth = "0.4.0"
+axum-macros = "0.3.7"
+bb8 = "0.8.0"
+bb8-redis = "0.13.0"
+chrono = { version = "0.4.24", features = ["serde"] }
+dotenvy = "0.15.7"
+futures = "0.3.28"
+hyper = { version = "0.14.26", features = ["full"] }
+once_cell = "1.17.1"
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
+opentelemetry-otlp = "0.11.0"
+parking_lot = "0.12.1"
+pin-project-lite = "0.2"
+rand_chacha = "0.3.1"
+redis = { version = "0.23.0", features = ["tokio-comp"] }
+reqwest = { version = "0.11.16", features = ["json"] }
+serde = { version = "1.0.160", features = ["derive"] }
+serde_json = "1.0.96"
+sqlx = { version = "0.6.3", features = [
+    "default",
+    "runtime-tokio-rustls",
+    "postgres",
+    "json",
+    "chrono",
+    "offline",
+] }
+thiserror = "1.0.40"
+tokio = { version = "1.27.0", features = ["macros"] }
+tower = "0.4.13"
+tower-cookies = "0.9.0"
+tower-http = { version = "0.4.0", features = ["full"] }
+tracing = "0.1.37"
+tracing-opentelemetry = "0.18.0"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+utoipa = { version = "3.3.0", features = ["axum_extras", "chrono"] }
+utoipa-swagger-ui = { version = "3.1.3", features = ["axum"] }
+validator = { version = "0.16.0", features = ["derive"] }

--- a/mi-api/Cargo.toml
+++ b/mi-api/Cargo.toml
@@ -1,44 +1,40 @@
 [package]
 name = "mi-api"
-version = "0.0.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.68"
-axum = { version = "0.6.16", features = ["macros", "http2"] }
-axum-auth = "0.4.0"
-axum-macros = "0.3.7"
-chrono = "0.4.24"
-rand_chacha = "0.3.1"
-dotenvy = "0.15.7"
-hyper = { version = "0.14.26", features = ["full"] }
-tracing = "0.1.37"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-tracing-opentelemetry = "0.18.0"
-tokio = { version = "1.27.0", features = ["full"] }
-tower = "0.4.13"
-tower-http = { version = "0.4.0", features = ["full"] }
-once_cell = "1.17.1"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry-otlp = "0.11.0"
-pin-project-lite = "0.2"
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0.96"
-sqlx = { version = "0.6.3", features = [
-    "default",
-    "runtime-tokio-rustls",
-    "postgres",
-] }
-reqwest = "0.11.16"
-tower-cookies = "0.9.0"
-utoipa = { version = "3.3.0", features = ["axum_extras", "chrono"] }
-utoipa-swagger-ui = { version = "3.1.3", features = ["axum"] }
 mi-db = { path = "../mi-db", version = "0.0.0" }
 mi-osu-api = { path = "../mi-osu-api", version = "0.0.0" }
-parking_lot = "0.12.1"
-validator = { version = "0.16.0", features = ["derive"] }
 
-bb8 = "0.8.0"
-bb8-redis = "0.13.0"
-redis = { version = "0.23.0", features = ["tokio-comp"] }
+sqlx.workspace = true
+async-trait.workspace = true
+axum.workspace = true
+axum-auth.workspace = true
+axum-macros.workspace = true
+chrono.workspace = true
+rand_chacha.workspace = true
+dotenvy.workspace = true
+hyper.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-opentelemetry.workspace = true
+tokio.workspace = true
+tower.workspace = true
+tower-http.workspace = true
+once_cell.workspace = true
+opentelemetry.workspace = true
+opentelemetry-otlp.workspace = true
+pin-project-lite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+reqwest.workspace = true
+tower-cookies.workspace = true
+utoipa.workspace = true
+utoipa-swagger-ui.workspace = true
+parking_lot.workspace = true
+validator.workspace = true
+bb8.workspace = true
+bb8-redis.workspace = true
+redis.workspace = true

--- a/mi-db/Cargo.toml
+++ b/mi-db/Cargo.toml
@@ -1,46 +1,34 @@
 [package]
 name = "mi-db"
-version = "0.0.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bb8 = "0.8.0"
-bb8-redis = "0.13.0"
-chrono = { version = "0.4.24", features = ["serde"] }
-futures = "0.3.28"
-redis = { version = "0.23.0", features = ["tokio-comp"] }
-sqlx = { version = "0.6.3", features = [
-    "default",
-    "runtime-tokio-rustls",
-    "postgres",
-    "json",
-    "chrono"
-] }
-serde = { version = "1.0.160", features = ["derive"] }
-serde_json = "1.0.96"
-thiserror = "1.0.40"
-tracing = "0.1.37"
-tokio = { version = "1.27.0", features = ["macros"] }
-utoipa = { version = "3.3.0", features = ["axum_extras"] }
 mi-osu-api = { path = "../mi-osu-api", version = "0.0.0" }
 
-[build-dependencies]
-dotenvy = "0.15.7"
-sqlx = { version = "0.6.3", features = [
-    "default",
-    "runtime-tokio-rustls",
-    "postgres",
-    "offline",
-] }
+bb8.workspace = true
+bb8-redis.workspace = true
+chrono.workspace = true
+futures.workspace = true
+redis.workspace = true
+sqlx.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+tokio.workspace = true
+utoipa.workspace = true
 
-tokio = { version = "1.27.0", features = ["macros"] }
+[build-dependencies]
+sqlx.workspace = true
+dotenvy.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
-futures = "0.3.28"
-once_cell = "1.17.1"
-tokio = { version = "1.27.0", features = ["macros"] }
+futures.workspace = true
+once_cell.workspace = true
+tokio.workspace = true
 
 [features]
 db-tests = []

--- a/mi-osu-api/Cargo.toml
+++ b/mi-osu-api/Cargo.toml
@@ -1,16 +1,15 @@
 [package]
 name = "mi-osu-api"
-version = "0.0.0"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dotenvy = "0.15.7"
-once_cell = "1.17.1"
-reqwest = { version = "0.11.16", features = ["json"] }
-serde = { version = "1.0.159", features = ["derive"] }
-serde_json = "1.0.95"
-thiserror = "1.0.40"
-tokio = { version = "1.27.0", features = ["macros"] }
-utoipa = { version = "3.1.2", features = ["axum_extras"] }
+dotenvy.workspace = true
+once_cell.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio.workspace = true
+utoipa.workspace = true


### PR DESCRIPTION
I moved everything to workspace dependencies except local crate dependencies from `mi-db` and `mi-osu-api`. I couldn't find a way to get them to work.